### PR TITLE
Исправление с не передающимся объектом query на сервере

### DIFF
--- a/lib/applicationAdapterServer.js
+++ b/lib/applicationAdapterServer.js
@@ -35,8 +35,7 @@ function getInstance ( stats, Layout, routes ){
           }
         );
       });
-      var racerBundle = yield racer.bundle( racerModel );
-
+      
       const markup = renderToStaticMarkup(
         React.createElement(
            racer.Provider,
@@ -46,6 +45,9 @@ function getInstance ( stats, Layout, routes ){
            )
         )
       );
+      
+      var racerBundle = yield racer.bundle( racerModel );
+      
       const response = renderToStaticMarkup(
         React.createElement( Layout, {
           hash: stats.hash,


### PR DESCRIPTION
Причина ошибки - вырезание данных и запросов из модели при создании бандла для отправки (видимо для экономии памяти на обработке прямого запроса)
